### PR TITLE
Bug修复，根据PHP8标准修改部分代码

### DIFF
--- a/README.md
+++ b/README.md
@@ -22,7 +22,13 @@
 
 1. 在Vercel上部署此仓库
 
-[![Deploy with Vercel](https://vercel.com/button)](https://vercel.com/new/clone?repository-url=https%3A%2F%2Fgithub.com%2Flwd-temp%2Fafdian-sponsor-page-vercel%2Ftree%2Fmain&env=USERID,TOKEN,PAGETITLE,USERNAME)
+采用此Fork版本库：
+
+[![Deploy with Vercel](https://vercel.com/button)](https://vercel.com/new/clone?repository-url=https%3A%2F%2Fgithub.com%2Flwd-temp%2Fafdian-sponsor-page-vercel%2Ftree%2Fvercel&env=USERID,TOKEN,PAGETITLE,USERNAME)
+
+或者采用上游仓库的对应分支：
+
+[![Deploy with Vercel](https://vercel.com/button)](https://vercel.com/new/clone?repository-url=https%3A%2F%2Fgithub.com%2FMisaLiu%2Fafdian-sponsor-page%2Ftree%2Fvercel&env=USERID,TOKEN,PAGETITLE,USERNAME)
 
 2. 获取你的爱发电 UserId 和 API Token [点此一键直达](https://afdian.net/dashboard/dev)
 

--- a/api/index.php
+++ b/api/index.php
@@ -1,16 +1,16 @@
 <?php
-    $pagetitlevar = getenv('PAGETITLE');
-    $usernamevar = getenv('USERNAME');
-    $useridvar = getenv('USERID');
-    $tokenvar = getenv('TOKEN');
-    // ===============你必须填写下面的必填参数才可以继续使用===============
+    // 从环境变量中获取参数
+    // 以下环境变量必须被设置
+    $pagetitlevar = getenv('PAGETITLE'); // 网页标题
+    $usernamevar = getenv('USERNAME'); // 你的用户名，即你的主页地址 @ 后面的那部分，如 https://afdian.net/@MisaLiu，那么 MisaLiu 就是你的用户名
+    $useridvar = getenv('USERID'); // 你的用户 ID，请前往 https://afdian.net/dashboard/dev 获取
+    $tokenvar = getenv('TOKEN'); // 你的 API Token，请前往 https://afdian.net/dashboard/dev 获取
     $_AFDIAN = array(
-        'pageTitle' => $pagetitlevar, // 网页标题
-        'userName'  => $usernamevar, // 你的用户名，即你的主页地址 @ 后面的那部分，如 https://afdian.net/@MisaLiu，那么 MisaLiu 就是你的用户名
-        'userId'    => $useridvar, // 你的用户 ID，请前往 https://afdian.net/dashboard/dev 获取
-        'token'     => $tokenvar    // 你的 API Token，请前往 https://afdian.net/dashboard/dev 获取
+        'pageTitle' => $pagetitlevar,
+        'userName'  => $usernamevar,
+        'userId'    => $useridvar,
+        'token'     => $tokenvar
     );
-    // ===============你必须填写上面的必填参数才可以继续使用===============
 
     $currentPage = !empty($_POST['page']) ? $_POST['page'] : 1;
 
@@ -20,7 +20,7 @@
     $data['ts']      = time();
     $data['sign']    = SignAfdian($_AFDIAN['token'], $data['params'], $_AFDIAN['userId']);
 
-    $result = HttpGet('https://afdian.net', '/api/open/query-sponsor', '', http_build_query($data));
+    $result = HttpGet('https://afdian.net', '/api/open/query-sponsor', http_build_query($data), '');
     $result = json_decode($result, true);
 
     $donator['total']     = $result['data']['total_count'];
@@ -142,7 +142,7 @@ HTML;
         return md5($sign, false);
     }
 
-    function HttpGet ($url, $dir, $method = 'GET', $data, $contentType = '', $timeout = 10) {
+    function HttpGet ($url, $dir,  $data, $method = 'GET', $contentType = '', $timeout = 10) {
         $ch = curl_init();
         curl_setopt($ch, CURLOPT_TIMEOUT, $timeout);
         if ($method == 'POST') {
@@ -163,4 +163,3 @@ HTML;
         curl_close($ch);
         return $output;
     }
-?>

--- a/vercel.json
+++ b/vercel.json
@@ -5,6 +5,7 @@
       }
     },
     "routes": [
-      { "src": "/",  "dest": "/api/index.php" }
+      { "src": "/",  "dest": "/api/index.php" },
+      { "src": "/index.php",  "dest": "/api/index.php" }
     ]
   }


### PR DESCRIPTION
自php8开始，函数中的必须参数（无默认值）需要始终排在可选参数（有默认值）的前面，
不然会在输出的页面里加警告的，会导致翻页时的API里出现弃用提示
~~本来想降级php但Vercel似乎不支持，所以就试图改了一点php，~~  希望上游开发者可以检查一下